### PR TITLE
fixes for AAC

### DIFF
--- a/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
+++ b/sys/net/gnrc/network_layer/ndp/internal/gnrc_ndp_internal.c
@@ -248,7 +248,10 @@ void gnrc_ndp_internal_send_nbr_sol(kernel_pid_t iface, ipv6_addr_t *src, ipv6_a
     DEBUG("dst: %s)\n", ipv6_addr_to_str(addr_str, dst, sizeof(addr_str)));
 
     /* check if there is a fitting source address to target */
-    if ((src == NULL) && ((src = gnrc_ipv6_netif_find_best_src_addr(iface, tgt)) != NULL)) {
+    if (src == NULL) {
+        src = gnrc_ipv6_netif_find_best_src_addr(iface, tgt);
+    }
+    if (src != NULL) {
         l2src_len = _get_l2src(iface, l2src, sizeof(l2src));
 
         if (l2src_len > 0) {

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -273,7 +273,10 @@ uint8_t gnrc_sixlowpan_nd_opt_ar_handle(kernel_pid_t iface, ipv6_hdr_t *ipv6, ui
             switch (ar_opt->status) {
                 case SIXLOWPAN_ND_STATUS_SUCCESS:
                     DEBUG("6lo nd: address registration successful\n");
+                    ipv6_addr_t *netif_addr_entry = gnrc_ipv6_netif_find_addr(iface, &(ipv6->dst));
+                    gnrc_ipv6_netif_addr_t *netif_addr = gnrc_ipv6_netif_addr_get(netif_addr_entry);
                     mutex_lock(&ipv6_iface->mutex);
+                    netif_addr->flags &= ~GNRC_IPV6_NETIF_ADDR_FLAGS_TENTATIVE;
                     /* reschedule 1 minute before lifetime expires */
                     timex_t t = { (uint32_t)(byteorder_ntohs(ar_opt->ltime) - 1) * 60, 0 };
                     vtimer_remove(&nc_entry->nbr_sol_timer);

--- a/sys/shell/commands/sc_netif.c
+++ b/sys/shell/commands/sc_netif.c
@@ -680,6 +680,7 @@ static int _netif_add(char *cmd_name, kernel_pid_t dev, int argc, char **argv)
     } type = _UNICAST;
     char *addr_str = argv[0];
     ipv6_addr_t addr;
+    ipv6_addr_t *assigned_address;
     uint8_t prefix_len;
 
     if (argc > 1) {
@@ -713,13 +714,16 @@ static int _netif_add(char *cmd_name, kernel_pid_t dev, int argc, char **argv)
         return 1;
     }
 
-    if (gnrc_ipv6_netif_add_addr(dev, &addr, prefix_len,
-                                 (type == _ANYCAST) ?
-                                 GNRC_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST :
-                                 GNRC_IPV6_NETIF_ADDR_FLAGS_UNICAST) == NULL) {
+    if ((assigned_address = gnrc_ipv6_netif_add_addr(dev, &addr, prefix_len,
+                                                    (type == _ANYCAST) ?
+                                                    GNRC_IPV6_NETIF_ADDR_FLAGS_NON_UNICAST :
+                                                    GNRC_IPV6_NETIF_ADDR_FLAGS_UNICAST))
+                           == NULL) {
         printf("error: unable to add IPv6 address\n");
         return 1;
     }
+    gnrc_ipv6_netif_addr_t *netif_addr = gnrc_ipv6_netif_addr_get(assigned_address);
+    netif_addr->flags &= ~GNRC_IPV6_NETIF_ADDR_FLAGS_TENTATIVE;
 
     printf("success: added %s/%d to interface %" PRIkernel_pid "\n", addr_str,
            prefix_len, dev);


### PR DESCRIPTION
This PR unset the TENTATIVE flag on the local address entry if appropriate and set the SL2AO in the neighbor solicitation if the source address is specified.